### PR TITLE
Make swagger API docs private on production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,10 @@
 # Required configuration
 API_KEY=your_api_key_here
 
+# API Documentation (disabled by default for security)
+# Set to "true" to enable /docs, /redoc, and /openapi.json endpoints
+# DOCS_ENABLED=true
+
 # Optional configuration - uncomment and set as needed
 # DOCLING_API_URL=http://custom-docling-api-url:port
 # DOCLING_SERVICE_NAME=docling-serve-cpu

--- a/app/app.py
+++ b/app/app.py
@@ -42,9 +42,9 @@ def create_application() -> FastAPI:
         title=settings.PROJECT_NAME,
         description="AI Hub providing document processing and AI services",
         version="0.1.0",
-        docs_url=settings.DOCS_URL,
-        redoc_url=settings.REDOC_URL,
-        openapi_url=settings.OPENAPI_URL,
+        docs_url=settings.DOCS_URL if settings.DOCS_ENABLED else None,
+        redoc_url=settings.REDOC_URL if settings.DOCS_ENABLED else None,
+        openapi_url=settings.OPENAPI_URL if settings.DOCS_ENABLED else None,
         lifespan=lifespan,
     )
     

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -26,6 +26,8 @@ class Settings(BaseSettings):
     RESULT_FETCH_TIMEOUT: float = 60.0
     
     # API Documentation settings
+    # Set DOCS_ENABLED=true to expose /docs, /redoc, /openapi.json (disabled by default for security)
+    DOCS_ENABLED: bool = os.getenv("DOCS_ENABLED", "false").lower() == "true"
     DOCS_URL: str = "/docs"
     REDOC_URL: str = "/redoc"
     OPENAPI_URL: str = "/openapi.json"

--- a/app/middleware/auth.py
+++ b/app/middleware/auth.py
@@ -14,9 +14,6 @@ AUTH_REQUIRED_PREFIXES = [
 # Paths that explicitly don't require authentication
 AUTH_EXCLUDED_PATHS = [
     "/health",
-    settings.DOCS_URL,
-    settings.OPENAPI_URL,
-    settings.REDOC_URL,
     f"{settings.API_V1_STR}/health",
 ]
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `DOCS_ENABLED` configuration option to control visibility of API documentation endpoints (/docs, /redoc, /openapi.json).

* **Security**
  * API documentation endpoints now require authentication by default, improving security posture.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->